### PR TITLE
A small fix for linker error

### DIFF
--- a/gl10/Makefile
+++ b/gl10/Makefile
@@ -16,7 +16,7 @@ ifeq ($(PLATFORM),Darwin)
 CGO_LDFLAGS:=-framework OpenGL -lGLEW
 CGO_CFLAGS:=-D__Darwin -framework OpenGL
 else
-CGO_LDFLAGS:=-lGLEW
+CGO_LDFLAGS:=-lGLEW -lGL
 CGO_CFLAGS:=-D__$(PLATFORM)
 endif
 

--- a/gl20/Makefile
+++ b/gl20/Makefile
@@ -16,7 +16,7 @@ ifeq ($(PLATFORM),Darwin)
 CGO_LDFLAGS:=-framework OpenGL -lGLEW
 CGO_CFLAGS:=-D__Darwin -framework OpenGL
 else
-CGO_LDFLAGS:=-lGLEW
+CGO_LDFLAGS:=-lGLEW -lGL
 CGO_CFLAGS:=-D__$(PLATFORM)
 endif
 

--- a/glu-gl10/Makefile
+++ b/glu-gl10/Makefile
@@ -14,7 +14,7 @@ ifeq ($(PLATFORM),Darwin)
 CGO_LDFLAGS:=-framework OpenGL -lGLEW
 CGO_CFLAGS:=-D__Darwin -framework OpenGL
 else
-CGO_LDFLAGS:=-lGLEW
+CGO_LDFLAGS:=-lGLEW -lGLU
 CGO_CFLAGS:=-D__$(PLATFORM)
 endif
 

--- a/glu/Makefile
+++ b/glu/Makefile
@@ -14,7 +14,7 @@ ifeq ($(PLATFORM),Darwin)
 CGO_LDFLAGS:=-framework OpenGL -lGLEW
 CGO_CFLAGS:=-D__Darwin -framework OpenGL
 else
-CGO_LDFLAGS:=-lGLEW
+CGO_LDFLAGS:=-lGLEW -lGL -lGLU
 CGO_CFLAGS:=-D__$(PLATFORM)
 endif
 


### PR DESCRIPTION
While compiling on Fedora 14 64 bits, I've had some linker errors like the following. Just found that linking explicitely with lGL and lGLU fixes them.

/usr/bin/ld: note: 'glPixelMapuiv' is defined in DSO /usr/lib64/libGL.so.1 so try adding it to the linker
/home/julien/dev/go/packages/Go-OpenGL/glu-gl10/glu.cgo2.c:42: undefined reference to `gluBuild2DMipmaps'
/home/julien/dev/go/packages/Go-OpenGL/glu-gl10/glu.cgo2.c:54: undefined reference to`gluPerspective'
