### PR TITLE
made the project compile on Mac OS X

### DIFF
--- a/gl/Makefile
+++ b/gl/Makefile
@@ -11,7 +11,7 @@ GOFILES:=gl_defs.go
 CGOFILES:=gl.go
 
 ifeq ($(GOOS),darwin)
-CGO_LDFLAGS:=-framework OpenGL -lGLEW -lGL
+CGO_LDFLAGS:=-framework OpenGL -lGLEW
 else
 CGO_LDFLAGS:=-lGLEW -lGL
 endif

--- a/gl/gl.go
+++ b/gl/gl.go
@@ -3,7 +3,7 @@ package gl
 // #include <stdlib.h>
 //
 // #ifdef __APPLE__
-// # include <OpenGL/glew.h>
+// # include <GL/glew.h>
 // #else
 // # include <GL/glew.h>
 // #endif


### PR DESCRIPTION
Hi,

I just tried to compile Go-SDL on my machine, and it didn't work. I read somewhere that you don't have access to a Mac so I made the necessary changes myself. It compiles fine now (there is one warning, but that shouldn't have to do with compiling on OSX itself, I posted it below).

One thing to note is that I'm using Homebrew to install Go, GLEW (1.5.8) and SDL. I'm not sure if other GLEW installs put glew.h in include/OpenGL, but for me it was in include/GL. Anyhow, I've seen quite a few people use Homebrew in the OS X developer community (at least the Ruby one), so the setup shouldn't be too uncommon.

The examples still crash, but so do the ones from Go-SDL. I'm currently trying to figure out if that's SDL's or the binding's fault. But has nothing to do with Go-OpenGL.

Hope this helps.

Regards,
Kolja

The warning:
gl.go: In function '_cgo_c3422dcf4751_Cfunc_glShaderSource':
gl.go:152: warning: passing argument 3 of '__glewShaderSource' from incompatible pointer type
