### PR TITLE
LDFLAGS as #cgo directives

### DIFF
--- a/gl/Makefile
+++ b/gl/Makefile
@@ -10,14 +10,6 @@ GOFILES:=gl_defs.go
 
 CGOFILES:=gl.go
 
-ifeq ($(GOOS),darwin)
-CGO_LDFLAGS:=-framework OpenGL -lGLEW -lGL
-else ifeq ($(GOOS),windows)
-CGO_LDFLAGS:=-lglew32 -lopengl32
-else
-CGO_LDFLAGS:=-lGLEW -lGL
-endif
-
 CLEANFILES+=gl
 
 include $(GOROOT)/src/Make.pkg

--- a/gl/gl.go
+++ b/gl/gl.go
@@ -1,5 +1,9 @@
 package gl
 
+// #cgo darwin LDFLAGS: -framework OpenGL -lGLEW -lGL
+// #cgo windows LDFLAGS: -lglew32 -lopengl32
+// #cgo linux LDFLAGS: -lGLEW -lGL
+//
 // #include <stdlib.h>
 //
 // #ifdef __APPLE__
@@ -10,7 +14,6 @@ package gl
 //
 // #undef GLEW_GET_FUN
 // #define GLEW_GET_FUN(x) (*x)
-//
 import "C"
 import "unsafe"
 import "reflect"

--- a/glu/Makefile
+++ b/glu/Makefile
@@ -8,14 +8,6 @@ TARG=gl/glu
 
 CGOFILES:=glu.go
 
-ifeq ($(GOOS),darwin)
-CGO_LDFLAGS:=-framework OpenGL
-else ifeq ($(GOOS),windows)
-CGO_LDFLAGS:=-lglu32
-else
-CGO_LDFLAGS:=-lGLU
-endif
-
 GC="${O}g" -I ../gl/_obj
 
 include $(GOROOT)/src/Make.pkg

--- a/glu/glu.go
+++ b/glu/glu.go
@@ -1,12 +1,14 @@
 package glu
 
+// #cgo darwin LDFLAGS: -framework OpenGL
+// #cgo windows LDFLAGS: -lglu32
+// #cgo linux LDFLAGS: -lGLU
+//
 // #ifdef __APPLE__
 // # include <OpenGL/glu.h>
 // #else
 // # include <GL/glu.h>
 // #endif
-//
-//
 import "C"
 import "gl"
 


### PR DESCRIPTION
Moved LDFLAGS code from Makefile conditionals to #cgo directives. Moving toward gl and glu as remote installable from go files.
