### PR TITLE
Update README.md to be compatible with go 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-This package works on Linux with go r60. You might be able to use it on Mac or even Windows, but it will require some effort.
+This package works on Linux with go 1.0. You might be able to use it on Mac or even Windows, but it will require some effort.
 
 You will need [GLEW](http://glew.sourceforge.net/) at least version 1.5.8.
 
 Some examples require [Go-SDL](github.com/banthar/Go-SDL) and some require [GLFW](github.com/jteeuwen/glfw).
 
-You can install this package with goinstall.
+You can install this package with go get.
 
-    sudo -E  goinstall github.com/banthar/gl
+    sudo -E  go get github.com/banthar/gl


### PR DESCRIPTION
The old README.md only worked with the old go versions, this works with go 1.0
