### PR TITLE
Add ability to pass a null pointer to glVertexAttribPointer

### DIFF
--- a/gl.go
+++ b/gl.go
@@ -686,13 +686,13 @@ func (indx AttribLocation) Attrib4fv(values []float32) {
 }
 
 func (indx AttribLocation) AttribPointer(size uint, normalized bool, stride int, pointer interface{}) {
-	// if p is a GLenum, pass it as the type instead
-	if enum, ok := pointer.(GLenum); ok {
-		C.glVertexAttribPointer(C.GLuint(indx), C.GLint(size), C.GLenum(enum), glBool(normalized), C.GLsizei(stride), nil)
-	} else {
-		t, p := GetGLenumType(pointer)
-		C.glVertexAttribPointer(C.GLuint(indx), C.GLint(size), C.GLenum(t), glBool(normalized), C.GLsizei(stride), p)
-	}
+	t, p := GetGLenumType(pointer)
+	C.glVertexAttribPointer(C.GLuint(indx), C.GLint(size), C.GLenum(t), glBool(normalized), C.GLsizei(stride), p)
+}
+
+func (indx AttribLocation) AttribNullPointer(size uint, normalized bool, stride int, tdata GLenum) {
+	// Use this function when you need pass a NULL pointer to glVertexAttribPointer
+	C.glVertexAttribPointer(C.GLuint(indx), C.GLint(size), C.GLenum(tdata), glBool(normalized), C.GLsizei(stride), nil)
 }
 
 func (indx AttribLocation) EnableArray() {


### PR DESCRIPTION
I was trying to work through some tutorials on OpenGL 3.3 (converting them from C to Go) and ran into a bit of code that alot of these OpenGL 3.3 tutorials seem to use:

``` C
glBindBuffer(GL_ARRAY_BUFFER, uiVBO[0]); 
glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, 0); 
glDrawArrays(GL_TRIANGLES, 0, 3); 
```

This was impossible to do with these OpenGL bindings because there was no way to pass a null to glVertexAttribPointer and still pass in a data type (i.e. GL_FLOAT). At first I modified the AttribPointer method to handle this special case if it got a GLenum value instead of pointer for the last function parameter, but I felt that this was just convolving two different functions into one. to make things simpler and clearer I split the functionality into a single new function:

``` Go
func (indx AttribLocation) AttribNullPointer(size uint, normalized bool, stride int, tdata GLenum) {
    // Use this function when you need pass a NULL pointer to glVertexAttribPointer
    C.glVertexAttribPointer(C.GLuint(indx), C.GLint(size), C.GLenum(tdata), glBool(normalized), C.GLsizei(stride), nil)
}
```

This allows me to use it in code as follows:

``` Go
    // Triangle render
    uiVBO[0].Bind(gl.ARRAY_BUFFER)
    vertexLocation.AttribNullPointer(3, false, 0, gl.FLOAT)
    gl.DrawArrays(gl.TRIANGLES, 0, 3)
```

I'd be interested in reworking the function or adding the functionality an alternate way if you have any ideas on a better implementation?

Nick.
