### PR TITLE
MapBuffer does not return a pointer to the mapped buffer

### DIFF
--- a/gl.go
+++ b/gl.go
@@ -627,8 +627,8 @@ func GetBufferSubData(target GLenum, offset int, size int, data interface{}) {
 }
 
 //  Map a buffer object's data store
-func MapBuffer(target GLenum, access GLenum) {
-	C.glMapBuffer(C.GLenum(target), C.GLenum(access))
+func MapBuffer(target GLenum, access GLenum) unsafe.Pointer {
+	return unsafe.Pointer(C.glMapBuffer(C.GLenum(target), C.GLenum(access)))
 }
 
 //  Unmap a buffer object's data store


### PR DESCRIPTION
The current implementation of MapBuffer just ignores the return value of glMapBuffer, giving no way to access the mapped buffer and no way to unmap it:

//  Map a buffer object's data store
func MapBuffer(target GLenum, access GLenum) {
    C.glMapBuffer(C.GLenum(target), C.GLenum(access))
}

It should return the location of the buffer somehow, but because the location given by the C function is of type void*, there is no single way it should always be returned.  The best proposal I've come up with is to give it an extra argument to indicate the desired return type and make it return an interface{} that will contain a slice of the desired type.
