### PR TITLE
Fix glUniform*v calls

### DIFF
--- a/uniformlocation.go
+++ b/uniformlocation.go
@@ -28,7 +28,7 @@ func (location UniformLocation) Uniform1fv(count int, v []float32) {
 	if len(v) < 1 {
 		panic("Invalid array length - must be at least 1")
 	}
-	C.glUniform1fv(C.GLint(location), C.GLsizei(count), (*C.GLfloat)(ptr(v)))
+	C.glUniform1fv(C.GLint(location), C.GLsizei(count), (*C.GLfloat)(&v[0]))
 }
 
 func (location UniformLocation) Uniform1i(x int) {


### PR DESCRIPTION
glUniform_v functions take a `count` parameter, which is the number of elements of the *uniform_ type (eg `vec4`), not the number of elements (eg `float32`) in the array. This patch fixes the bug by adding a `count` param on the go side, with a panic() if the array does not have at least 1 element (while OpenGL allows a count of 0, we need to take the address of the first element).
