### PR TITLE
Added and changed the Uniform functions.

### DIFF
--- a/uniformlocation.go
+++ b/uniformlocation.go
@@ -25,123 +25,80 @@ func (location UniformLocation) Uniform3f(x float32, y float32, z float32) {
 	C.glUniform3f(C.GLint(location), C.GLfloat(x), C.GLfloat(y), C.GLfloat(z))
 }
 
-func (location UniformLocation) Uniform1ui(x uint) {
-	C.glUniform1ui(C.GLint(location), C.GLuint(x))
-}
-func (location UniformLocation) Uniform2ui(x uint, y uint) {
-	C.glUniform2ui(C.GLint(location), C.GLuint(x), C.GLuint(y))
-}
-
-func (location UniformLocation) Uniform3ui(x uint, y uint, z uint) {
-	C.glUniform3ui(C.GLint(location), C.GLuint(x), C.GLuint(y), C.GLuint(z))
-}
-
-func (location UniformLocation) Uniform4ui(x uint, y uint, z uint, w uint) {
-	C.glUniform4ui(C.GLint(location), C.GLuint(x), C.GLuint(y), C.GLuint(z), C.GLuint(w))
-}
-
-func (location UniformLocation) Uniform1uiv(v ...uint32) {
+func (location UniformLocation) Uniform1fv(count int, v []float32) {
 	if len(v) < 1 {
 		panic("Invalid array length - must be at least 1")
 	}
-	C.glUniform1uiv(C.GLint(location), C.GLsizei(len(v)), (*C.GLuint)((unsafe.Pointer)(&v[0])))
-}
-
-func (location UniformLocation) Uniform2uiv(v ...[2]uint32) {
-	if len(v) < 1 {
-		panic("Invalid array length - must be at least 1")
-	}
-	C.glUniform2uiv(C.GLint(location), C.GLsizei(len(v)), (*C.GLuint)((unsafe.Pointer)(&v[0])))
-}
-
-func (location UniformLocation) Uniform3uiv(v ...[3]uint32) {
-	if len(v) < 1 {
-		panic("Invalid array length - must be at least 1")
-	}
-	C.glUniform3uiv(C.GLint(location), C.GLsizei(len(v)), (*C.GLuint)((unsafe.Pointer)(&v[0])))
-}
-
-func (location UniformLocation) Uniform4uiv(v ...[4]uint32) {
-	if len(v) < 1 {
-		panic("Invalid array length - must be at least 1")
-	}
-	C.glUniform4uiv(C.GLint(location), C.GLsizei(len(v)), (*C.GLuint)((unsafe.Pointer)(&v[0])))
-}
-
-func (location UniformLocation) Uniform1fv(v ...float32) {
-	if len(v) < 1 {
-		panic("Invalid array length - must be at least 1")
-	}
-	C.glUniform1fv(C.GLint(location), C.GLsizei(len(v)), (*C.GLfloat)((unsafe.Pointer)(&v[0])))
+	C.glUniform1fv(C.GLint(location), C.GLsizei(count), (*C.GLfloat)(&v[0]))
 }
 
 func (location UniformLocation) Uniform1i(x int) {
 	C.glUniform1i(C.GLint(location), C.GLint(x))
 }
 
-func (location UniformLocation) Uniform1iv(v ...int32) {
+func (location UniformLocation) Uniform1iv(count int, v []int32) {
 	if len(v) < 1 {
 		panic("Invalid array length - must be at least 1")
 	}
-	C.glUniform1iv(C.GLint(location), C.GLsizei(len(v)), (*C.GLint)((unsafe.Pointer)(&v[0])))
+	C.glUniform1iv(C.GLint(location), C.GLsizei(count), (*C.GLint)(&v[0]))
 }
 
-func (location UniformLocation) Uniform2fv(v ...[2]float32) {
+func (location UniformLocation) Uniform2fv(count int, v []float32) {
 	if len(v) < 1 {
 		panic("Invalid array length - must be at least 1")
 	}
-	C.glUniform2fv(C.GLint(location), C.GLsizei(len(v)), (*C.GLfloat)((unsafe.Pointer)(&v[0])))
+	C.glUniform2fv(C.GLint(location), C.GLsizei(count), (*C.GLfloat)(&v[0]))
 }
 
 func (location UniformLocation) Uniform2i(x int, y int) {
 	C.glUniform2i(C.GLint(location), C.GLint(x), C.GLint(y))
 }
 
-func (location UniformLocation) Uniform2iv(v ...[2]int32) {
+func (location UniformLocation) Uniform2iv(count int, v []int32) {
 	if len(v) < 1 {
 		panic("Invalid array length - must be at least 1")
 	}
-	C.glUniform2iv(C.GLint(location), C.GLsizei(len(v)), (*C.GLint)((unsafe.Pointer)(&v[0])))
+	C.glUniform2iv(C.GLint(location), C.GLsizei(count), (*C.GLint)(&v[0]))
 }
 
-func (location UniformLocation) Uniform3fv(v ...[3]float32) {
+func (location UniformLocation) Uniform3fv(count int, v []float32) {
 	if len(v) < 1 {
 		panic("Invalid array length - must be at least 1")
 	}
-	C.glUniform3fv(C.GLint(location), C.GLsizei(len(v)), (*C.GLfloat)((unsafe.Pointer)(&v[0])))
+	C.glUniform3fv(C.GLint(location), C.GLsizei(count), (*C.GLfloat)(&v[0]))
 }
 
 func (location UniformLocation) Uniform3i(x int, y int, z int) {
 	C.glUniform3i(C.GLint(location), C.GLint(x), C.GLint(y), C.GLint(z))
 }
 
-func (location UniformLocation) Uniform3iv(v ...[3]int32) {
+func (location UniformLocation) Uniform3iv(count int, v []int32) {
 	if len(v) < 1 {
 		panic("Invalid array length - must be at least 1")
 	}
-	C.glUniform3iv(C.GLint(location), C.GLsizei(len(v)), (*C.GLint)((unsafe.Pointer)(&v[0])))
+	C.glUniform3iv(C.GLint(location), C.GLsizei(count), (*C.GLint)(&v[0]))
 }
 
 func (location UniformLocation) Uniform4f(x float32, y float32, z float32, w float32) {
 	C.glUniform4f(C.GLint(location), C.GLfloat(x), C.GLfloat(y), C.GLfloat(z), C.GLfloat(w))
 }
 
-func (location UniformLocation) Uniform4fv(v ...[4]float32) {
+func (location UniformLocation) Uniform4fv(count int, v []float32) {
 	if len(v) < 1 {
 		panic("Invalid array length - must be at least 1")
 	}
-	C.glUniform4fv(C.GLint(location), C.GLsizei(len(v)), (*C.GLfloat)((unsafe.Pointer)(&v[0])))
+	C.glUniform4fv(C.GLint(location), C.GLsizei(count), (*C.GLfloat)(&v[0]))
 }
 
 func (location UniformLocation) Uniform4i(x int, y int, z int, w int) {
 	C.glUniform4i(C.GLint(location), C.GLint(x), C.GLint(y), C.GLint(z), C.GLint(w))
 }
 
-func (location UniformLocation) Uniform4iv(v ...[4]int32) {
+func (location UniformLocation) Uniform4iv(count int, v []int32) {
 	if len(v) < 1 {
 		panic("Invalid array length - must be at least 1")
 	}
-	C.glUniform4iv(C.GLint(location), C.GLsizei(len(v)), (*C.GLint)((unsafe.Pointer)(&v[0])))
+	C.glUniform4iv(C.GLint(location), C.GLsizei(count), (*C.GLint)(&v[0]))
 }
 
 func (location UniformLocation) UniformMatrix2fv(transpose bool, list ...[4]float32) {


### PR DESCRIPTION
I've changed <code>Uniform_fv(count int,v []float32)</code> to <code>Uniform_fv(v ...[*]float32)</code>.
removed the count because you can use slices,
and I think there is more chance someone will use <code>[]Vector2/3/4</code> instead of <code>[]float32</code>, also they can use reflect&unsafe to convert []float32/anything to <code>[]Vector2/3/4</code>. (it was already true before the change)
<code>(type Vector2 [2]float32)</code>

Added <code>UniformMatrix_fv</code> and <code>UniformMatrix_f</code>, <code>UniformMatrix*f</code> is not a real function in opengl but its optimized for using 1 matrix when you already got the pointer.

Added unsigned int functions as well.
