### PR TITLE
Issue #97 fixing readme:<More libraries> links

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Examples can be found in our [examples repository](https://github.com/go-gl/exam
 * [GLFW bindings](https://github.com/go-gl/glfw) for easy windowing, input etc.
 * [gltext](https://github.com/go-gl/gltext) a native go library for glyph packing and text rendering
 * [glu](https://github.com/go-gl/glu) GLU bindings
-* [glchart](https://github.com/go-gl/glchart) a [go chart](https://www.github.com/vdobler/chart) OpenGL backend
+* [glchart](https://github.com/go-gl/glchart) a [go chart](https://github.com/vdobler/chart) OpenGL backend
 * [gldebug](https://github.com/go-gl/gldebug) graphical timing and memory debugging utilities
 
 # Problems and contributing


### PR DESCRIPTION
The links should now work as absolute links. (Issue #97 )
