### PR TITLE
Added Query Objects

### DIFF
--- a/gl_defs.go
+++ b/gl_defs.go
@@ -58,6 +58,7 @@ const (
 	AND_INVERTED                                  = C.GL_AND_INVERTED
 	AND_REVERSE                                   = C.GL_AND_REVERSE
 	AND                                           = C.GL_AND
+	ANY_SAMPLES_PASSED                            = C.GL_ANY_SAMPLES_PASSED
 	ARRAY_BUFFER_BINDING                          = C.GL_ARRAY_BUFFER_BINDING
 	ARRAY_BUFFER                                  = C.GL_ARRAY_BUFFER
 	ATTACHED_SHADERS                              = C.GL_ATTACHED_SHADERS
@@ -1232,6 +1233,8 @@ const (
 	TEXTURE                                       = C.GL_TEXTURE
 	TIMEOUT_EXPIRED                               = C.GL_TIMEOUT_EXPIRED
 	TIMEOUT_IGNORED                               = C.GL_TIMEOUT_IGNORED
+	TIMESTAMP                                     = C.GL_TIMESTAMP
+	TIME_ELAPSED                                  = C.GL_TIME_ELAPSED
 	TRANSFORM_FEEDBACK                            = C.GL_TRANSFORM_FEEDBACK
 	TRANSFORM_BIT                                 = C.GL_TRANSFORM_BIT
 	TRANSFORM_FEEDBACK_BUFFER_BINDING             = C.GL_TRANSFORM_FEEDBACK_BUFFER_BINDING

--- a/object.go
+++ b/object.go
@@ -15,6 +15,8 @@ func (object Object) IsBuffer() bool { return C.glIsBuffer(C.GLuint(object)) != 
 
 func (object Object) IsProgram() bool { return C.glIsProgram(C.GLuint(object)) != 0 }
 
+func (object Object) IsQuery() bool { return C.glIsQuery(C.GLuint(object)) != 0 }
+
 func (object Object) IsShader() bool { return C.glIsShader(C.GLuint(object)) != 0 }
 
 func (object Object) IsTexture() bool { return C.glIsTexture(C.GLuint(object)) != 0 }

--- a/query.go
+++ b/query.go
@@ -1,0 +1,96 @@
+// Copyright 2012 The go-gl Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gl
+
+// #include "gl.h"
+import "C"
+
+type Query Object
+
+func GenQuery() (q Query) {
+	C.glGenQueries(1, (*C.GLuint)(&q))
+	return
+}
+
+func GenQueries(queries []Query) {
+	if len(queries) > 0 {
+		C.glGenQueries(C.GLsizei(len(queries)), (*C.GLuint)(&queries[0]))
+	}
+}
+
+func (query Query) Begin(target GLenum) {
+	C.glBeginQuery(C.GLenum(target), C.GLuint(query))
+}
+
+func (query Query) BeginIndexed(target GLenum, index uint) {
+	C.glBeginQueryIndexed(C.GLenum(target), C.GLuint(index), C.GLuint(query))
+}
+
+func (query Query) Delete() {
+	C.glDeleteQueries(1, (*C.GLuint)(&query))
+}
+
+func (query Query) GetObjecti(pname GLenum) (param int32) {
+	C.glGetQueryObjectiv(C.GLuint(query), C.GLenum(pname), (*C.GLint)(&param))
+	return
+}
+
+func (query Query) GetObjectui(pname GLenum) (param uint32) {
+	C.glGetQueryObjectuiv(C.GLuint(query), C.GLenum(pname), (*C.GLuint)(&param))
+	return
+}
+
+func (query Query) GetObjecti64(pname GLenum) (param int64) {
+	C.glGetQueryObjecti64v(C.GLuint(query), C.GLenum(pname), (*C.GLint64)(&param))
+	return
+}
+
+func (query Query) GetObjectui64(pname GLenum) (param uint64) {
+	C.glGetQueryObjectui64v(C.GLuint(query), C.GLenum(pname), (*C.GLuint64)(&param))
+	return
+}
+
+func (query Query) Counter(target GLenum) {
+	C.glQueryCounter(C.GLuint(query), C.GLenum(target))
+}
+
+// Returns whether the passed samples counter is immediately available. If a delay
+// would not occur waiting for the query result, true is returned, which also indicates
+// that the results of all previous queries are available as well.
+func (query Query) ResultAvailable() bool {
+	return query.GetObjectui(QUERY_RESULT_AVAILABLE) == TRUE
+}
+
+func (query Query) BeginConditionalRender(mode GLenum) {
+	C.glBeginConditionalRender(C.GLuint(query), C.GLenum(mode))
+}
+
+func DeleteQueries(queries []Query) {
+	if len(queries) > 0 {
+		C.glDeleteQueries(C.GLsizei(len(queries)), (*C.GLuint)(&queries[0]))
+	}
+}
+
+func EndQuery(target GLenum) {
+	C.glEndQuery(C.GLenum(target))
+}
+
+func GetQuery(target GLenum, pname GLenum) (param int32) {
+	C.glGetQueryiv(C.GLenum(target), C.GLenum(pname), (*C.GLint)(&param))
+	return
+}
+
+func GetQueryIndexed(target GLenum, index uint, pname GLenum) (param int32) {
+	C.glGetQueryIndexediv(C.GLenum(target), C.GLuint(index), C.GLenum(pname), (*C.GLint)(&param))
+	return
+}
+
+func (query Query) EndQueryIndexed(target GLenum, index uint) {
+	C.glEndQueryIndexed(C.GLenum(target), C.GLuint(index))
+}
+
+func (query Query) EndConditionalRender() {
+	C.glEndConditionalRender()
+}


### PR DESCRIPTION
Query Objects can be used for profiling and occlusion.

https://www.opengl.org/wiki/Query_Object

This does not include Query Buffer Objects which are not supported in the GLEW version we use.
