### PR TITLE
Added MapBuffer convenience functions for slices

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -84,6 +84,9 @@ func MapBuffer(target GLenum, access GLenum) unsafe.Pointer {
 
 // Maps the buffer with MapBuffer() and returns a pointer to the slice pointing
 // to the mapped buffer. See also the MapBuffer<Type> convenience functions.
+// WARNING: This function makes use of reflect.SliceHeader which may reduce
+// portability of your application. See the reflect.SliceHeader documentation
+// for more information.
 func MapBufferSlice(target GLenum, access GLenum, bytesPerElement int) unsafe.Pointer {
 	rawLength := int(GetBufferParameteriv(target, BUFFER_SIZE))
 	return unsafe.Pointer(&reflect.SliceHeader{


### PR DESCRIPTION
Go's way of dealing with lots of data is through arrays and slices. Yet the currently available MapBuffer function returns a C like pointer.
I created some functions that return slices rather than pointers.
