### PR TITLE
Fix code design for the program type

### DIFF
--- a/program.go
+++ b/program.go
@@ -60,6 +60,9 @@ func (program Program) Validate() { C.glValidateProgram(C.GLuint(program)) }
 
 func (program Program) Use() { C.glUseProgram(C.GLuint(program)) }
 
+func (program Program) Unuse() { C.glUseProgram(C.GLuint(0)) }
+
+// Deprecated, please use program.Unuse()
 func ProgramUnuse() { C.glUseProgram(C.GLuint(0)) }
 
 func (program Program) GetInfoLog() string {


### PR DESCRIPTION
As discussed in #143, it's better to attach the `Unuse()` function to
the type, even if it doesn't use it, rather than a standalone function
like before (`programUnuse()`)
