### PR TITLE
Added compiler flags to get Cgo to find GLEW. OS X

### DIFF
--- a/attriblocation.go
+++ b/attriblocation.go
@@ -4,6 +4,7 @@
 
 package gl
 
+//#cgo darwin CFLAGS: -I/usr/local/include
 // #include "gl.h"
 import "C"
 

--- a/gl.go
+++ b/gl.go
@@ -4,7 +4,7 @@
 
 package gl
 
-// #cgo darwin LDFLAGS: -framework OpenGL -lGLEW
+// #cgo darwin LDFLAGS: -framework OpenGL -lGLEW -L/usr/local/lib
 // #cgo windows LDFLAGS: -lglew32 -lopengl32
 // #cgo linux LDFLAGS: -lGLEW -lGL
 // #cgo freebsd  CFLAGS: -I/usr/local/include


### PR DESCRIPTION
Similar to my previous request for glfw3. I may have gotten the file placement wrong.
Still, the library was not building for me on OS X 10.9.4, and this fixed it.
