### PR TITLE
Add support for GL_ARB_get_program_binary (core in OpenGL 4.1)

### DIFF
--- a/gl_arb_get_program_binary.go
+++ b/gl_arb_get_program_binary.go
@@ -1,0 +1,37 @@
+// Copyright 2012 The go-gl Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gl
+
+// #include "gl.h"
+import "C"
+import "unsafe"
+
+const (
+	NUM_PROGRAM_BINARY_FORMATS      = C.GL_NUM_PROGRAM_BINARY_FORMATS
+	PROGRAM_BINARY_FORMATS          = C.GL_PROGRAM_BINARY_FORMATS
+	PROGRAM_BINARY_LENGTH           = C.GL_PROGRAM_BINARY_LENGTH
+	PROGRAM_BINARY_RETRIEVABLE_HINT = C.GL_PROGRAM_BINARY_RETRIEVABLE_HINT
+)
+
+// Binary loads a program object with a binary previously returned from GetBinary.
+func (program Program) Binary(format GLenum, binary []byte) {
+	C.glProgramBinary(C.GLuint(program), C.GLenum(format), unsafe.Pointer(&binary[0]), C.GLsizei(len(binary)))
+}
+
+// Parameteri sets an integer program parameter to the specified value.
+func (program Program) Parameteri(pname GLenum, value int) {
+	C.glProgramParameteri(C.GLuint(program), C.GLenum(pname), C.GLint(value))
+}
+
+// GetBinary retrieves a program's binary, it returns the actual program length
+// (which may be different than len(binary)) and its binary encoding format.
+func (program Program) GetBinary(binary []byte) (length int, format GLenum) {
+	var glformat C.GLenum
+	var gllength C.GLsizei
+
+	C.glGetProgramBinary(C.GLuint(program), C.GLsizei(len(binary)), &gllength, &glformat, unsafe.Pointer(&binary[0]))
+	length, format = int(gllength), GLenum(glformat)
+	return
+}

--- a/gl_arb_get_program_binary.go
+++ b/gl_arb_get_program_binary.go
@@ -30,7 +30,6 @@ func (program Program) Parameteri(pname GLenum, value int) {
 func (program Program) GetBinary(binary []byte) (length int, format GLenum) {
 	var glformat C.GLenum
 	var gllength C.GLsizei
-
 	C.glGetProgramBinary(C.GLuint(program), C.GLsizei(len(binary)), &gllength, &glformat, unsafe.Pointer(&binary[0]))
 	length, format = int(gllength), GLenum(glformat)
 	return


### PR DESCRIPTION
Extension is documented at:
https://www.opengl.org/registry/specs/ARB/get_program_binary.txt

This extension adds support for caching compiled program binaries and loading
them back from direct binary data.
Support has been added by adding appropriate OpenGL enumerations and the:
Binary(), Parameteri(), GetBinary() methods to the Program type.
